### PR TITLE
Added copy buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,25 +132,67 @@
             they use system font faces.</p>
           </div>
         </div>
+    
+        <!-- SVG Icons for Copy Buttons -->
+        <svg style="display:none;">
+          <defs>
+            <symbol id="copy-icon" viewBox="0 0 20 20">
+            <path fill="none" stroke="currentColor" 
+            stroke-linecap="round" stroke-linejoin="round" 
+            d="M15.5 13.5v5h-11v-15h3m0 1v-2h1.1a1.5 1.5 0 012.8 0h1.1v2h-5Zm11 6h-9l3-3-3 3 3 3m0-10h3v4"/>
+          </symbol>
+            <symbol id="success-icon" viewBox="0 0 20 20">
+            <path fill="none" stroke="currentColor" 
+            stroke-linecap="round" stroke-linejoin="round" 
+            stroke-width="1.5" d="m3.5 10.5 4 4 9-9" />
+          </symbol>
+          </defs>
+        </svg>
+      
         <div class="mt5">
           <h1 class="fw5 f3 mb4 mt2">Basic system font stacks</h1>
           <h1 class="fw5 f4 mt3 mb2">Sans-serif</h1>
-          <div>
-            <div class="code overflow-none lh-copy">
+          <div class="flex ba-ns b--moon-gray br3 overflow-hidden-ns">
+            <div id="sans-serif" class="code overflow-none lh-copy flex-auto pa3-ns">
               font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, Cantarell, Ubuntu, roboto, noto, helvetica, arial, sans-serif;
             </div>
+            <button data-copy="sans-serif" 
+            aria-label="Copy Sans-serif font stack to clipboard." 
+            style="flex:0 0 4rem;border:unset;border-left:1px solid #ccc;" 
+            class="bl b--silver mid-gray f6-ns pointer bg-light-gray hover-bg-black-10 bg-animate">
+              <svg style="width:1.5rem;height:1.5rem;">
+                <use href="#copy-icon" />
+              </svg>
+              <span>Copy</span>
+            </button>
           </div>
-          <h1 class="fw5 f4 mt3 mb2">Serif</h1>
-          <div>
-            <div class="code overflow-none lh-copy">
+          <h1 class="fw5 f4 mt4 mb2">Serif</h1>
+          <div class="flex ba-ns b--moon-gray br3 overflow-hidden-ns">
+            <div id="serif" class="code overflow-none lh-copy flex-auto pa3-ns">
               font-family: Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
             </div>
+            <button data-copy="serif" aria-label="Copy Serif font stack to clipboard." 
+            style="flex:0 0 4rem;border:unset;border-left:1px solid #ccc;" 
+            class="bl b--silver mid-gray f6-ns pointer bg-light-gray hover-bg-black-10 bg-animate">
+              <svg style="width:1.5rem;height:1.5rem;">
+                <use href="#copy-icon" />
+              </svg>
+              <span>Copy</span>
+            </button>
           </div>
-          <h1 class="fw5 f4 mt3 mb2">Mono</h1>
-          <div>
-            <div class="code overflow-none lh-copy">
+          <h1 class="fw5 f4 mt4 mb2">Mono</h1>
+          <div class="flex ba-ns b--moon-gray br3 overflow-hidden-ns">
+            <div id="mono" class="code overflow-none lh-copy flex-auto pa3-ns">
               font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
             </div>
+            <button data-copy="mono" aria-label="Copy monospace font stack to clipboard." 
+            style="flex:0 0 4rem;border:unset;border-left:1px solid #ccc;" 
+            class="bl b--silver mid-gray f6-ns pointer bg-light-gray hover-bg-black-10 bg-animate">
+              <svg style="width:1.5rem;height:1.5rem;">
+                <use href="#copy-icon" />
+              </svg>
+              <span>Copy</span>
+            </button>
           </div>
         </div>
         <hr class="bt b--black-20 mw5 center mt5">
@@ -196,5 +238,39 @@
         </div>
       </div>
   </div>
+<script>
+document.querySelectorAll('button[data-copy]').forEach((button) => {
+  button.addEventListener('click', () => {
+    const codeId = button.getAttribute('data-copy');
+    const codeDiv = document.getElementById(codeId);
+    if (codeDiv && codeDiv.textContent && codeDiv.textContent.length > 0) {
+
+      // Create a temporary textarea to copy the text
+      const tempTextarea = document.createElement('textarea');
+      tempTextarea.value = codeDiv.textContent.trim();
+      document.body.appendChild(tempTextarea);
+      tempTextarea.select();
+      const copied = document.execCommand('copy');
+      document.body.removeChild(tempTextarea);
+
+      // If text copied successfully › provide feedback to user
+      if (copied) {
+        button.classList.add('green','bg-washed-green','hover-bg-washed-green');
+        const buttonIcon = button.querySelector('use');
+        buttonIcon.setAttribute('href', '#success-icon');
+        const buttonText = button.querySelector('span');
+        buttonText.textContent = 'Copied!';
+        setTimeout(() => {
+          button.classList.remove('green','bg-washed-green','hover-bg-washed-green');
+          buttonIcon.setAttribute('href','#copy-icon');
+          buttonText.textContent = 'Copy';
+        }, 2000);
+      } else {
+        console.error('Failed to copy text');
+      }
+    }
+  });
+});
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -239,38 +239,38 @@
       </div>
   </div>
 <script>
-document.querySelectorAll('button[data-copy]').forEach((button) => {
-  button.addEventListener('click', () => {
-    const codeId = button.getAttribute('data-copy');
-    const codeDiv = document.getElementById(codeId);
-    if (codeDiv && codeDiv.textContent && codeDiv.textContent.length > 0) {
-
-      // Create a temporary textarea to copy the text
-      const tempTextarea = document.createElement('textarea');
-      tempTextarea.value = codeDiv.textContent.trim();
-      document.body.appendChild(tempTextarea);
-      tempTextarea.select();
-      const copied = document.execCommand('copy');
-      document.body.removeChild(tempTextarea);
-
-      // If text copied successfully › provide feedback to user
-      if (copied) {
-        button.classList.add('green','bg-washed-green','hover-bg-washed-green');
-        const buttonIcon = button.querySelector('use');
-        buttonIcon.setAttribute('href', '#success-icon');
-        const buttonText = button.querySelector('span');
-        buttonText.textContent = 'Copied!';
-        setTimeout(() => {
-          button.classList.remove('green','bg-washed-green','hover-bg-washed-green');
-          buttonIcon.setAttribute('href','#copy-icon');
-          buttonText.textContent = 'Copy';
-        }, 2000);
-      } else {
-        console.error('Failed to copy text');
-      }
+(() => {
+  async function copyText(textToCopy) {
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+    } catch (err) {
+      console.error('Failed to copy css:', err);
     }
+  }
+  document.querySelectorAll('button[data-copy]').forEach((button) => {
+    button.addEventListener('click',() => {
+      const codeId = button.getAttribute('data-copy');
+      if (!codeId) return;
+      const codeDiv = document.getElementById(codeId);
+      if (codeDiv && codeDiv.textContent) {
+        copyText(codeDiv.textContent.trim())
+          .then(() => {
+            button.classList.add('green','bg-washed-green','hover-bg-washed-green');
+            const buttonIcon = button.querySelector('use');
+            buttonIcon?.setAttribute('href', '#success-icon');
+            const buttonText = button.querySelector('span');
+            if (buttonText) buttonText.textContent = 'Copied!';
+            setTimeout(() => {
+              button.classList.remove('green','bg-washed-green','hover-bg-washed-green');
+              buttonIcon?.setAttribute('href', '#copy-icon');
+              if (buttonText) buttonText.textContent = 'Copy';
+            }, 2000);
+          })
+          .catch((err) => { console.error('Failed to copy css:', err); });
+      }
+    });
   });
-});
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
I'm a big fan of your [systemfontstack.com](https://systemfontstack.com). I visit the site very frequently.

I wanted to make it easier for visitors to copy the code so I added a copy button to the right of each font stack and a small amount of javascript to copy the code to the user's clipboard.

![screenshot-of-changes](https://github.com/user-attachments/assets/1b231848-b17f-4d66-979a-f93fbdb945cc)

I tried as much as possible to use the existing CSS classes in [tachyons.min.css](https://github.com/tmcw/systemfontstack/blob/master/tachyons.min.css). I wrote the SVG icons by hand trying to make them clear and inkeeping with the aesthetic of your site.

## Summary of the changes:

1) Added SVG icons for Copy to Clipboard and Success – [lines 135 - 151](https://github.com/tmcw/systemfontstack/commit/17383ffd88f7756ce4d960447222ecf077369d2b#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R135-R151)
2) Made each code box a horizontal flexbox and added an `id` attribute to each block of code.
3) Added a copy button on the right side of each flexbox e.g. [lines 159 - 167](https://github.com/tmcw/systemfontstack/commit/17383ffd88f7756ce4d960447222ecf077369d2b#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R159-R167)
4) Wrote a small script – [lines 241 - 274](https://github.com/tmcw/systemfontstack/commit/17383ffd88f7756ce4d960447222ecf077369d2b#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R241-R274)
    - Add `click` event listeners to each button
    - Get the code from the `<div>` specified by the `data-code` attribute on the button
    - Create a temporary textarea to allow selecting the text before running `document.execCommand('copy')`
    - If copy succeeds update the button color and icon to green using existing classes.
    - Revert back to original copy button after 2 seconds.

